### PR TITLE
Trim horoscope output

### DIFF
--- a/pyhoroscope.py
+++ b/pyhoroscope.py
@@ -1,6 +1,5 @@
 import urllib.request
 from lxml import etree
-import re
 
 ####################################################################
 # API

--- a/pyhoroscope.py
+++ b/pyhoroscope.py
@@ -19,6 +19,7 @@ class Horoscope:
         horoscope = str(tree.xpath(
 			"//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
         horoscope = horoscope.replace("[\"\\r\\n   ", "").replace("    \\r\\n    \\r\\n  \"]", "")
+        horoscope = horoscope.strip()
         dict = {
             'date': date,
             'horoscope': horoscope,
@@ -39,6 +40,7 @@ class Horoscope:
         horoscope = str(tree.xpath(
 			"//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
         horoscope = horoscope.replace("\\r\\n   ", "").replace("     \\r\\n  ", "").replace("    \\r\\n    \\r\\n  ", "").replace("['", "").replace("']", "")
+        horoscope = horoscope.strip()
         dict = {
             'week': week,
             'horoscope': horoscope,
@@ -59,6 +61,7 @@ class Horoscope:
         horoscope = str(tree.xpath(
 			"//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()[1]"))
         horoscope = horoscope.replace("\\r\\n   ", "").replace("['", "").replace("']", "")
+        horoscope = horoscope.strip()
         dict = {
             'month': month,
             'horoscope': horoscope,
@@ -79,6 +82,7 @@ class Horoscope:
         horoscope = str(tree.xpath(
 			"//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
         horoscope = horoscope.replace("['\\r\\n   ", "").replace("    \\r\\n    \\r\\n  ", "").replace("[u'", "").replace("']", "").replace("\\xe2\\x80\\x99s", "")
+        horoscope = horoscope.strip()
         dict = {
             'year': year,
             'horoscope': horoscope,

--- a/pyhoroscope.py
+++ b/pyhoroscope.py
@@ -1,23 +1,27 @@
 import urllib.request
 from lxml import etree
 
+
 ####################################################################
 # API
 ####################################################################
 
 class Horoscope:
+    def __init__(self):
+        pass
 
     @staticmethod
     def get_todays_horoscope(sunsign):
         url = "http://www.ganeshaspeaks.com/horoscopes/daily-horoscope/" + sunsign
         response = urllib.request.urlopen(url)
-        htmlparser = etree.HTMLParser()
-        tree = etree.parse(response, htmlparser)
+        html_parser = etree.HTMLParser()
+        tree = etree.parse(response, html_parser)
         date = str(tree.xpath(
-			"//*[@id=\"daily\"]/div/div[1]/div[1]/div[2]/div/p/text()"))
+            "//*[@id=\"daily\"]/div/div[1]/div[1]/div[2]/div/p/text()"))
         date = date.replace("['", "").replace("']", "").replace("['(", "").replace(")']", "")
+
         horoscope = str(tree.xpath(
-			"//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
+            "//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
         horoscope = horoscope.replace("[\"\\r\\n   ", "").replace("    \\r\\n    \\r\\n  \"]", "")
         horoscope = horoscope.strip()
         dict = {
@@ -32,14 +36,16 @@ class Horoscope:
     def get_weekly_horoscope(sunsign):
         url = "http://www.ganeshaspeaks.com/horoscopes/weekly-horoscope/" + sunsign
         response = urllib.request.urlopen(url)
-        htmlparser = etree.HTMLParser()
-        tree = etree.parse(response, htmlparser)
+        html_parser = etree.HTMLParser()
+        tree = etree.parse(response, html_parser)
         week = str(tree.xpath(
-			"//*[@id=\"daily\"]/div/div[1]/div[1]/div[2]/div/p/text()"))
-        week = week.replace("['", "").replace("[u'\\n", "").replace("']", "").replace("\\u2013", "-")
+            "//*[@id=\"daily\"]/div/div[1]/div[1]/div[2]/div/p/text()"))
+        week = week.replace("['", "").replace("[u'\\n", "").replace("']", "").replace("\\u2013",
+                                                                                      "-")
         horoscope = str(tree.xpath(
-			"//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
-        horoscope = horoscope.replace("\\r\\n   ", "").replace("     \\r\\n  ", "").replace("    \\r\\n    \\r\\n  ", "").replace("['", "").replace("']", "")
+            "//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
+        horoscope = horoscope.replace("\\r\\n   ", "").replace("     \\r\\n  ", "").replace(
+            "    \\r\\n    \\r\\n  ", "").replace("['", "").replace("']", "")
         horoscope = horoscope.strip()
         dict = {
             'week': week,
@@ -53,13 +59,14 @@ class Horoscope:
     def get_monthly_horoscope(sunsign):
         url = "http://www.ganeshaspeaks.com/horoscopes/monthly-horoscope/" + sunsign
         response = urllib.request.urlopen(url)
-        htmlparser = etree.HTMLParser()
-        tree = etree.parse(response, htmlparser)
+        html_parser = etree.HTMLParser()
+        tree = etree.parse(response, html_parser)
         month = str(tree.xpath(
-			"//*[@id=\"daily\"]/div/div[1]/div[1]/div[2]/div/p/text()"))
-        month = month.replace("['", "").replace("\\r\\n   ", "").replace("['\\n", "").replace("']", "")
+            "//*[@id=\"daily\"]/div/div[1]/div[1]/div[2]/div/p/text()"))
+        month = month.replace("['", "").replace("\\r\\n   ", "").replace("['\\n", "").replace("']",
+                                                                                              "")
         horoscope = str(tree.xpath(
-			"//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()[1]"))
+            "//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()[1]"))
         horoscope = horoscope.replace("\\r\\n   ", "").replace("['", "").replace("']", "")
         horoscope = horoscope.strip()
         dict = {
@@ -74,14 +81,17 @@ class Horoscope:
     def get_yearly_horoscope(sunsign):
         url = "http://www.ganeshaspeaks.com/horoscopes/yearly-horoscope/" + sunsign
         response = urllib.request.urlopen(url)
-        htmlparser = etree.HTMLParser()
-        tree = etree.parse(response, htmlparser)
+        html_parser = etree.HTMLParser()
+        tree = etree.parse(response, html_parser)
         year = str(tree.xpath(
-			"//*[@id=\"daily\"]/div/div[1]/div[1]/div[2]/div/p/text()"))
+            "//*[@id=\"daily\"]/div/div[1]/div[1]/div[2]/div/p/text()"))
         year = year.replace("['", "").replace("['\\n", "").replace("']", "")
+
         horoscope = str(tree.xpath(
-			"//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
-        horoscope = horoscope.replace("['\\r\\n   ", "").replace("    \\r\\n    \\r\\n  ", "").replace("[u'", "").replace("']", "").replace("\\xe2\\x80\\x99s", "")
+            "//*[@id=\"daily\"]/div/div[1]/div[2]/p[1]/text()"))
+        horoscope = horoscope.replace("['\\r\\n   ", "").replace("    \\r\\n    \\r\\n  ",
+                                                                 "").replace("[u'", "").replace(
+            "']", "").replace("\\xe2\\x80\\x99s", "")
         horoscope = horoscope.strip()
         dict = {
             'year': year,


### PR DESCRIPTION
I got this response 
```json
{
  "date": "14-08-2017", 
  "horoscope": "     Be sure of your strengths and decisions, and Ganesha guarantees you success. You don't care what others think about you, but don't be so indifferent that you ignore their choices, preferences and comforts completely. The smile of you sweetheart will work like a charm and you will forget all your worries, feels Ganesha.   ", 
  "sunsign": "aquarius"
}
```

Which has whitespace characters in the horoscope output. This PR fixes that + cleans up the code to make it conform to [PEP-8](https://www.python.org/dev/peps/pep-0008/), a popular style guide for Python.